### PR TITLE
Namespaced models

### DIFF
--- a/lib/resourceful/builder.rb
+++ b/lib/resourceful/builder.rb
@@ -27,7 +27,7 @@ module Resourceful
       @responses        = {}
       @publish          = {}
       @parents          = []
-      @shallow_route    = false
+      @shallow_parent   = nil
       @custom_member_actions = []
       @custom_collection_actions = []
     end
@@ -59,7 +59,7 @@ module Resourceful
       kontroller.made_resourceful = true
 
       kontroller.parents = @parents
-      kontroller.shallow_route = @shallow_route
+      kontroller.shallow_parent = @shallow_parent
       kontroller.model_namespace = @model_namespace
       kontroller.before_filter :load_object, :only => (@ok_actions & SINGULAR_PRELOADED_ACTIONS) + @custom_member_actions
       kontroller.before_filter :load_objects, :only => (@ok_actions & PLURAL_ACTIONS) + @custom_collection_actions
@@ -361,7 +361,11 @@ module Resourceful
     def belongs_to(*parents)
       options = parents.extract_options!
       @parents = parents.map(&:to_s)
-      @shallow_route = !!options[:shallow_route]
+      if options[:shallow]
+        options[:shallow] = options[:shallow].to_s
+        raise ArgumentError, ":shallow needs the name of a parent resource" unless @parents.include? options[:shallow]
+        @shallow_parent = options[:shallow]
+      end
     end
     
     # Specifies a namespace for the resource model. It can be given as a

--- a/lib/resourceful/default/accessors.rb
+++ b/lib/resourceful/default/accessors.rb
@@ -212,10 +212,12 @@ module Resourceful
         !!parent_name
       end
 
-      # Returns true if the belongs_to relationship on this controller was
-      # declared to use shallow routing.
-      def shallow_route?
-        !!self.class.shallow_route
+      # Returns true if no parent id parameter can be found _and_ a belongs_to
+      # relationship on this controller was declared with a parent for shallow
+      # routing.
+      def shallow?
+        self.class.shallow_parent &&
+          (parent_name.nil? || parent_name == self.class.shallow_parent)
       end
 
       # Returns whether the parent (if it exists) is polymorphic

--- a/lib/resourceful/default/urls.rb
+++ b/lib/resourceful/default/urls.rb
@@ -124,7 +124,7 @@ module Resourceful
       end
 
       def instance_route(name, object, type, action = nil)
-        send("#{action ? action + '_' : ''}#{url_helper_prefix}#{collection_url_prefix unless shallow_route?}#{name}_#{type}", *(parent? && !shallow_route? ? [parent_object, object] : [object]))
+        send("#{action ? action + '_' : ''}#{url_helper_prefix}#{collection_url_prefix unless shallow?}#{name}_#{type}", *(parent? && !shallow? ? [parent_object, object] : [object]))
       end
 
       def collection_route(name, type, action = nil)

--- a/lib/resourceful/maker.rb
+++ b/lib/resourceful/maker.rb
@@ -12,7 +12,7 @@ module Resourceful
       base.class_attribute :resourceful_callbacks
       base.class_attribute :resourceful_responses
       base.class_attribute :parents
-      base.class_attribute :shallow_route
+      base.class_attribute :shallow_parent
       base.class_attribute :model_namespace
       base.class_attribute :made_resourceful
       


### PR DESCRIPTION
Hey guys, I whipped up a quick patch to allow namespaced models. It adds a method, `model_namespace`, to the builder, and a new accessor, `namespaced_model_name`, to accessors.rb, that gets used by `current_model` to find the correct model for `current_objects` and `current_object`.
