### PR TITLE
Response and callback blocks should not be shared across controllers when using with rails 3

### DIFF
--- a/lib/resourceful/builder.rb
+++ b/lib/resourceful/builder.rb
@@ -52,9 +52,12 @@ module Resourceful
 
       kontroller.hidden_actions.reject! &@ok_actions.method(:include?)
       kontroller.send :include, @action_module
-
-      kontroller.resourceful_callbacks.merge! @callbacks
-      kontroller.resourceful_responses.merge! @responses
+      
+      merged_callbacks = kontroller.resourceful_callbacks.merge @callbacks
+      merged_responses = kontroller.resourceful_responses.merge @responses
+      
+      kontroller.resourceful_callbacks = merged_callbacks
+      kontroller.resourceful_responses = merged_responses
       kontroller.made_resourceful = true
 
       kontroller.parents = @parents


### PR DESCRIPTION
This should solve the similarly-named controller issue.

In Rails 3 class_attribute doesn't behave the same as inheritable_attributes in Rails 2 did. Inherited attributes aren't duped. It handles not propagating changes up the inheritance hierarchy, but only through the setter. ANy mutations of an inherited attribute are made on the original referenced object.

Since, merge! was being used in Builder, every make_resourceful call was adding its response and callback blocks into  the original hashes off ActionController::Base.

My patch switches to using merge to ensure that we're always dealing with a copy rather than the original hash.
