### PR TITLE
fixed scope to work with rails 3.1.1

### DIFF
--- a/lib/resourceful/default/callbacks.rb
+++ b/lib/resourceful/default/callbacks.rb
@@ -35,8 +35,8 @@ module Resourceful
       # The returned block accepts no arguments,
       # even if the given block accepted them.
       def scope(block)
-        lambda do
-          instance_eval(&(block || lambda {}))
+        proc do
+          instance_eval(&(block || proc {}))
         end
       end
 


### PR DESCRIPTION
- replaces lambda calls with proc.
- everything works in rails 3.1.1 with ruby 1.9.2
