### PR TITLE
Fix incompatibility with ActiveSupport::Dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.gem
 tags
 testapp
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gemspec

--- a/lib/resourceful/builder.rb
+++ b/lib/resourceful/builder.rb
@@ -41,7 +41,7 @@ module Resourceful
       apply_publish
 
       kontroller = @controller
-      
+
       Resourceful::ACTIONS.each do |action_named|
         # See if this is a method listed by #actions
         unless @ok_actions.include? action_named
@@ -53,10 +53,10 @@ module Resourceful
 
       kontroller.hidden_actions.reject! &@ok_actions.method(:include?)
       kontroller.send :include, @action_module
-      
+
       merged_callbacks = kontroller.resourceful_callbacks.merge @callbacks
       merged_responses = kontroller.resourceful_responses.merge @responses
-      
+
       kontroller.resourceful_callbacks = merged_callbacks
       kontroller.resourceful_responses = merged_responses
       kontroller.made_resourceful = true
@@ -72,7 +72,7 @@ module Resourceful
     # :call-seq:
     #   actions(*available_actions)
     #   actions :all
-    # 
+    #
     # Adds the default RESTful actions to the controller.
     #
     # If the only argument is <tt>:all</tt>,
@@ -108,19 +108,19 @@ module Resourceful
       available_actions.each { |action| @ok_actions << action.to_sym }
     end
     alias build actions
-    
+
     # :call-seq:
     #   member_actions(*available_actions)
-    # 
+    #
     # Registers custom member actions which will use the load_object before_filter.
     # These actions are not created, but merely registered for filtering.
     def member_actions(*available_actions)
       available_actions.each { |action| @custom_member_actions << action.to_sym }
     end
-    
+
     # :call-seq:
     #   collection_actions(*available_actions)
-    # 
+    #
     # Registers custom collection actions which will use the load_objects before_filter.
     # These actions are not created, but merely registered for filtering.
     def collection_actions(*available_actions)
@@ -148,11 +148,11 @@ module Resourceful
     # to the current object's title
     # for the show and edit actions.
     #
-    # Successive before blocks for the same action will be chained and executed 
+    # Successive before blocks for the same action will be chained and executed
     # in order when the event occurs.
     #
     # For example:
-    #    
+    #
     #   before :show, :edit do
     #     @page_title = current_object.title
     #   end
@@ -161,7 +161,7 @@ module Resourceful
     #     @side_bar = true
     #   end
     #
-    # These before blocks will both be executed for the show action and in the 
+    # These before blocks will both be executed for the show action and in the
     # same order as they were defined.
     def before(*events, &block)
       add_callback :before, *events, &block
@@ -230,7 +230,7 @@ module Resourceful
     #   end
     #
     # This is the same as
-    #     
+    #
     #   response_for :new do |format|
     #     format.html { render :action => 'edit' }
     #   end
@@ -277,8 +277,8 @@ module Resourceful
     #
     # Then GET /posts/12.yaml would render
     #
-    #   --- 
-    #   post: 
+    #   ---
+    #   post:
     #     title: Cool Stuff
     #     rendered_content: |-
     #       <p>This is a post.</p>
@@ -331,7 +331,7 @@ module Resourceful
         :only => [:show, :index]
       }.merge(Hash === formats.last ? formats.pop : {})
       raise "Must specify :attributes option" unless options[:attributes]
-      
+
       Array(options.delete(:only)).each do |action|
         @publish[action] ||= []
         formats.each do |format|
@@ -370,7 +370,7 @@ module Resourceful
         @shallow_parent = options[:shallow]
       end
     end
-    
+
     # Specifies a namespace for the resource model. It can be given as a
     # Module::NameSpace, 'Module::NameSpace' (in a string), or
     # 'module/name_space' (underscored form).
@@ -387,7 +387,7 @@ module Resourceful
     end
 
     private
-    
+
     def apply_publish
       @publish.each do |action, types|
         @responses[action.to_sym] ||= []
@@ -395,10 +395,10 @@ module Resourceful
       end
     end
 
-    def add_callback(type, *events, &block)    
+    def add_callback(type, *events, &block)
       events.each do |event|
         @callbacks[type][event.to_sym] ||= []
-        @callbacks[type][event.to_sym] << block        
+        @callbacks[type][event.to_sym] << block
       end
     end
   end

--- a/lib/resourceful/builder.rb
+++ b/lib/resourceful/builder.rb
@@ -61,7 +61,7 @@ module Resourceful
       kontroller.resourceful_responses = merged_responses
       kontroller.made_resourceful = true
 
-      kontroller.parents = @parents
+      kontroller.parent_controllers = @parents
       kontroller.shallow_parent = @shallow_parent
       kontroller.model_namespace = @model_namespace
       kontroller.before_filter :load_object, :only => (@ok_actions & SINGULAR_PRELOADED_ACTIONS) + @custom_member_actions

--- a/lib/resourceful/default/accessors.rb
+++ b/lib/resourceful/default/accessors.rb
@@ -194,7 +194,7 @@ module Resourceful
       #
       # Note that the parents must be declared via Builder#belongs_to.
       def parent_names
-        self.class.parents
+        self.class.parent_controllers
       end
 
       # Returns true if an appropriate parent id parameter has been supplied.

--- a/lib/resourceful/maker.rb
+++ b/lib/resourceful/maker.rb
@@ -11,14 +11,14 @@ module Resourceful
     def self.extended(base)
       base.class_attribute :resourceful_callbacks
       base.class_attribute :resourceful_responses
-      base.class_attribute :parents
+      base.class_attribute :parent_controllers
       base.class_attribute :shallow_parent
       base.class_attribute :model_namespace
       base.class_attribute :made_resourceful
-      
+
       base.resourceful_callbacks = {}
       base.resourceful_responses = {}
-      base.parents               = []
+      base.parent_controllers    = []
       base.model_namespace       = nil
       base.made_resourceful      = false
     end

--- a/lib/resourceful/maker.rb
+++ b/lib/resourceful/maker.rb
@@ -53,7 +53,7 @@ module Resourceful
     #       current_object.current_user = current_user
     #     end
     #   end
-    # 
+    #
     def make_resourceful(options = {}, &block)
       # :stopdoc:
       include Resourceful::Base


### PR DESCRIPTION
This fixes an issue with newer versions of ActiveSupport: resourceful/maker adds a `parents` class methods – something that AS::Dependencies uses for its autoloading spiel.

It's only an issue in autoload-environments (ie. development).

Sorry, no tests – the existing test suite is broken.
